### PR TITLE
fix: CD 배포 파이프라인 (Nohup -> Systemd 전환)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,43 +69,17 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << EOF
             cd ${{ env.DEPLOY_PATH }}
-            mkdir -p logs
+            
+            # Restart Service (env.conf already exists)
+            echo "서비스 재시작..."
+            sudo systemctl restart moyeobab-api
 
-            PID=\$(pgrep -f "${{ env.JAR_NAME }}" || true)
-            if [ -n "\$PID" ]; then
-              echo "프로세스 종료 중... (PID: \$PID)"
-              kill -15 \$PID
-
-              for i in {1..30}; do
-                if ! ps -p \$PID > /dev/null 2>&1; then
-                  echo "정상 종료"
-                  break
-                fi
-                sleep 1
-              done
-
-              if ps -p \$PID > /dev/null 2>&1; then
-                kill -9 \$PID
-                sleep 2
-              fi
-            fi
-
-            export DB_URL="${{ secrets.DB_URL }}"
-            export DB_USERNAME="${{ secrets.DB_USERNAME }}"
-            export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
-            export REDIS_HOST="${{ secrets.REDIS_HOST }}"
-            export REDIS_PORT="${{ secrets.REDIS_PORT }}"
-            export REDIS_PASSWORD="${{ secrets.REDIS_PASSWORD }}"
-
-            nohup java -jar ${{ env.JAR_NAME }} > logs/app.log 2>&1 &
-            disown
-
-            sleep 15
-
-            if pgrep -f "${{ env.JAR_NAME }}" > /dev/null; then
-              echo "배포 완료 - 프로세스 실행 중"
+            # Check status
+            if systemctl is-active --quiet moyeobab-api; then
+              echo "배포 완료 - 서비스 실행 중"
             else
-              echo "배포 실패 - 프로세스가 실행되지 않음"
+              echo "배포 실패 - 서비스 실행 실패"
+              systemctl status moyeobab-api --no-pager
               exit 1
             fi
           EOF
@@ -117,10 +91,11 @@ jobs:
           MAX_RETRY=10
           RETRY_INTERVAL=5
 
-          for i in $(seq 1 $MAX_RETRY); do
+          for i in $(seq 1 $MAX_RETRY);
+          do
             echo "Smoke Test $i/$MAX_RETRY..."
 
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{{http_code}}" \
               --max-time 10 \
               https://api.moyeobab.com/actuator/health || echo "000")
 
@@ -144,65 +119,118 @@ jobs:
           ssh -i ~/.ssh/deploy_key ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << EOF
             cd ${{ env.DEPLOY_PATH }}
 
-            PID=\$(pgrep -f "${{ env.JAR_NAME }}" || true)
-            if [ -n "\$PID" ]; then
-              kill -9 \$PID
-              sleep 2
-            fi
-
             if [ -f "${{ env.BACKUP_PATH }}/${{ env.JAR_NAME }}.backup" ]; then
+              echo "롤백 시작..."
+              # Stop service
+              sudo systemctl stop moyeobab-api
+              
+              # Restore file
               cp ${{ env.BACKUP_PATH }}/${{ env.JAR_NAME }}.backup ${{ env.DEPLOY_PATH }}/${{ env.JAR_NAME }}
 
-              export DB_URL="${{ secrets.DB_URL }}"
-              export DB_USERNAME="${{ secrets.DB_USERNAME }}"
-              export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
-              export REDIS_HOST="${{ secrets.REDIS_HOST }}"
-              export REDIS_PORT="${{ secrets.REDIS_PORT }}"
-              export REDIS_PASSWORD="${{ secrets.REDIS_PASSWORD }}"
+              # Restart service
+              sudo systemctl start moyeobab-api
 
-              nohup java -jar ${{ env.JAR_NAME }} > logs/app.log 2>&1 &
-              disown
-
-              sleep 15
               echo "롤백 완료"
             else
               echo "백업 파일 없음 (최초 배포)"
             fi
           EOF
 
-      # ===== Stage 5: 알림 =====
-      - name: Notify Success
-        if: success()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [{
-                "title": "BE 배포 완료",
-                "color": 5763719,
-                "fields": [
-                  {"name": "브랜치", "value": "main", "inline": true},
-                  {"name": "CI Run", "value": "#${{ github.event.workflow_run.run_number }}", "inline": true}
-                ],
-                "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
-              }]
-            }' \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-      - name: Notify Failure
-        if: failure()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [{
-                "title": "BE 배포 실패",
-                "description": "롤백이 실행되었습니다.",
-                "color": 15548997,
-                "fields": [
-                  {"name": "브랜치", "value": "main", "inline": true},
-                  {"name": "CI Run", "value": "#${{ github.event.workflow_run.run_number }}", "inline": true},
-                  {"name": "로그", "value": "[확인하기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})", "inline": false}
-                ],
-                "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
-              }]
-            }' \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            # ===== Stage 5: 알림 =====
+            - name: Notify Success
+              if: success()
+              env:
+                DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                TITLE: "🚀 배포 성공: moyeobab-api"
+                DESCRIPTION: "새로운 버전이 EC2 서버에 정상적으로 배포되었습니다."
+                COLOR: 3066993
+                URL: ${{ github.event.workflow_run.html_url }}
+                COMMIT_MSG: ${{ github.event.workflow_run.head_commit.message }}
+                AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
+                RUN_NUM: ${{ github.event.workflow_run.run_number }}
+              run: |
+                TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                
+                jq -n \
+                  --arg title "$TITLE" \
+                  --arg desc "$DESCRIPTION" \
+                  --arg url "$URL" \
+                  --arg color "$COLOR" \
+                  --arg msg "$COMMIT_MSG" \
+                  --arg author "$AUTHOR" \
+                  --arg run_num "$RUN_NUM" \
+                  --arg ts "$TIMESTAMP" \
+                  '{
+                    username: "Moyeobab Deploy Bot",
+                    avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                    embeds: [{
+                      title: $title,
+                      url: $url,
+                      description: $desc,
+                      color: ($color | tonumber),
+                      fields: [
+                        {name: "🌿 브랜치", value: "main", inline: true},
+                        {name: "🔢 빌드 번호", value: ("#" + $run_num), inline: true},
+                        {name: "👤 작성자", value: $author, inline: true},
+                        {name: "📝 커밋 메시지", value: $msg, inline: false}
+                      ],
+                      footer: {
+                        text: "Powered by Systemd & Github Actions",
+                        icon_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+                      },
+                      timestamp: $ts
+                    }]
+                  }' > payload.json
+      
+                curl -H "Content-Type: application/json" \
+                  -d @payload.json \
+                  "$DISCORD_WEBHOOK"
+            - name: Notify Failure
+              if: failure()
+              env:
+                DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                TITLE: "❌ 배포 실패 (롤백 완료)"
+                DESCRIPTION: "배포 중 오류가 발생하여 **자동 롤백**이 수행되었습니다. 서버는 이전 안정 버전으로 복구되었습니다."
+                COLOR: 15158332
+                URL: ${{ github.event.workflow_run.html_url }}
+                COMMIT_MSG: ${{ github.event.workflow_run.head_commit.message }}
+                AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
+                RUN_NUM: ${{ github.event.workflow_run.run_number }}
+              run: |
+                TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                
+                jq -n \
+                  --arg title "$TITLE" \
+                  --arg desc "$DESCRIPTION" \
+                  --arg url "$URL" \
+                  --arg color "$COLOR" \
+                  --arg msg "$COMMIT_MSG" \
+                  --arg author "$AUTHOR" \
+                  --arg run_num "$RUN_NUM" \
+                  --arg ts "$TIMESTAMP" \
+                  '{
+                    username: "Moyeobab Deploy Bot",
+                    avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                    embeds: [{
+                      title: $title,
+                      url: $url,
+                      description: $desc,
+                      color: ($color | tonumber),
+                      fields: [
+                        {name: "🌿 브랜치", value: "main", inline: true},
+                        {name: "🔢 빌드 번호", value: ("#" + $run_num), inline: true},
+                        {name: "👤 작성자", value: $author, inline: true},
+                        {name: "📝 커밋 메시지", value: $msg, inline: false},
+                        {name: "🔍 로그 확인", value: ("[Github Actions 바로가기](" + $url + ")"), inline: false}
+                      ],
+                      footer: {
+                        text: "Powered by Systemd & Github Actions",
+                        icon_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+                      },
+                      timestamp: $ts
+                    }]
+                  }' > payload.json
+      
+                curl -H "Content-Type: application/json" \
+                  -d @payload.json \
+                  "$DISCORD_WEBHOOK"


### PR DESCRIPTION
## 변경 사항 요약
기존의 불안정한 nohup 기반 배포 스크립트를 리눅스 표준 서비스 관리자인 Systemd 기반으로 전면 개편하였습니다. 이를 통해 배포 안정성을 확보하고, 운영 편의성을 대폭 개선하였습니다.

### 1. 배포 프로세스 변경
- **Before:** nohup java -jar ... & 및 kill -9를 사용하는 복잡한 쉘 스크립트
- **After:** sudo systemctl restart moyeobab-api 명령어 사용
- **효과:**
    - 프로세스 자동 재시작(Auto-restart) 지원으로 가용성 확보
    - 배포 스크립트 복잡도 65% 감소 (52줄 -> 18줄)
    - 불필요한 sleep 대기 시간 제거

### 2. 자동 롤백(Rollback) 로직 개선
- 배포 후 Smoke Test 실패 시 systemctl을 통해 안정적으로 서비스를 내리고 백업본으로 원복하도록 수정하였습니다.

### 3. 기타 개선
- Discord 알림: jq를 도입하여 알림 포맷(Embed)을 개선하고, 커밋 메시지, 작성자, 빌드 번호 등 상세 정보를 포함하도록 수정했습니다.

## 체크리스트
- [x] 서버(EC2)에 moyeobab-api.service 등록 완료
- [x] 서버에 env.conf 환경 변수 파일 존재 확인
- [x] 로컬 빌드 및 테스트 통과 확인
