### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/matchimban/matchimban_api/auth/jwt/RefreshTokenService.java
+++ b/src/main/java/com/matchimban/matchimban_api/auth/jwt/RefreshTokenService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class RefreshTokenService {
 
 	private static final String KEY_PREFIX = "refresh:";
+	private static final String INDEX_PREFIX = "refresh_idx:"; // refreshHash -> memberId:sid 역인덱스 키 프리픽스
 	private static final String FIELD_REFRESH_HASH = "refreshHash";
 	private static final String FIELD_ISSUED_AT = "issuedAt";
 	private static final String FIELD_ROTATED_AT = "rotatedAt";
@@ -37,19 +38,47 @@ public class RefreshTokenService {
 	public String issue(Long memberId, String sid, String device) {
 		// 발급된 refresh 원문은 저장하지 않고 해시만 저장한다.
 		String refreshToken = generateToken();
+		String refreshHash = hash(refreshToken);
 		String key = buildKey(memberId, sid);
 
 		Map<String, String> values = new HashMap<>();
-		values.put(FIELD_REFRESH_HASH, hash(refreshToken));
+		values.put(FIELD_REFRESH_HASH, refreshHash);
 		values.put(FIELD_ISSUED_AT, String.valueOf(Instant.now().toEpochMilli()));
 		if (device != null && !device.isBlank()) {
 			values.put(FIELD_DEVICE, device);
 		}
 
 		redisTemplate.opsForHash().putAll(key, values);
-		redisTemplate.expire(key, Duration.ofDays(jwtProperties.refreshTokenExpireDays()));
+		Duration ttl = Duration.ofDays(jwtProperties.refreshTokenExpireDays());
+		redisTemplate.expire(key, ttl);
+		// refreshHash로 세션을 찾을 수 있도록 역인덱스를 함께 저장한다.
+		redisTemplate.opsForValue().set(buildIndexKey(refreshHash), buildIndexValue(memberId, sid), ttl);
 
 		return refreshToken;
+	}
+
+	public Optional<RefreshSession> resolveSession(String refreshToken) {
+		// refresh 토큰만으로 memberId/sid를 역조회한다.
+		String refreshHash = hash(refreshToken);
+		String indexValue = redisTemplate.opsForValue().get(buildIndexKey(refreshHash));
+		if (indexValue == null || indexValue.isBlank()) {
+			return Optional.empty();
+		}
+
+		String[] parts = indexValue.split(":", 2); // "memberId:sid" 형식
+		if (parts.length != 2) {
+			return Optional.empty();
+		}
+		try {
+			Long memberId = Long.valueOf(parts[0]);
+			String sid = parts[1];
+			if (sid.isBlank()) {
+				return Optional.empty();
+			}
+			return Optional.of(new RefreshSession(memberId, sid));
+		} catch (NumberFormatException ex) {
+			return Optional.empty();
+		}
 	}
 
 	public Optional<String> rotate(Long memberId, String sid, String presentedToken, String device) {
@@ -63,26 +92,40 @@ public class RefreshTokenService {
 		if (!presentedHash.equals(storedHash.toString())) {
 			//  즉시 세션 폐기 (sid 강제 로그아웃)
 			redisTemplate.delete(key);
+			// 잘못된 refresh 재사용 시 역인덱스도 함께 정리한다.
+			deleteIndex(storedHash.toString());
+			deleteIndex(presentedHash);
 			return Optional.empty();
 		}
 
 		// Rotation: 새 refresh 발급 → 해시 갱신 → 기존 refresh는 즉시 무효화
 		String newRefreshToken = generateToken();
+		String newRefreshHash = hash(newRefreshToken);
 		Map<String, String> updates = new HashMap<>();
-		updates.put(FIELD_REFRESH_HASH, hash(newRefreshToken));
+		updates.put(FIELD_REFRESH_HASH, newRefreshHash);
 		updates.put(FIELD_ROTATED_AT, String.valueOf(Instant.now().toEpochMilli()));
 		if (device != null && !device.isBlank()) {
 			updates.put(FIELD_DEVICE, device);
 		}
 
 		redisTemplate.opsForHash().putAll(key, updates);
-		redisTemplate.expire(key, Duration.ofDays(jwtProperties.refreshTokenExpireDays()));
+		Duration ttl = Duration.ofDays(jwtProperties.refreshTokenExpireDays());
+		redisTemplate.expire(key, ttl);
+		// 기존 refresh 해시 인덱스를 제거하고 신규 해시로 교체한다.
+		deleteIndex(presentedHash);
+		redisTemplate.opsForValue().set(buildIndexKey(newRefreshHash), buildIndexValue(memberId, sid), ttl);
 
 		return Optional.of(newRefreshToken);
 	}
 
 	public void revoke(Long memberId, String sid) {
-		redisTemplate.delete(buildKey(memberId, sid));
+		String key = buildKey(memberId, sid);
+		Object storedHash = redisTemplate.opsForHash().get(key, FIELD_REFRESH_HASH);
+		redisTemplate.delete(key);
+		// 세션 삭제 시 역인덱스도 함께 제거한다.
+		if (storedHash != null) {
+			deleteIndex(storedHash.toString());
+		}
 	}
 
 	public void revokeAll(Long memberId) {
@@ -92,11 +135,36 @@ public class RefreshTokenService {
 		if (keys == null || keys.isEmpty()) {
 			return;
 		}
+		var indexKeys = new java.util.ArrayList<String>(); // 세션 키에 매핑된 역인덱스를 함께 수집한다.
+		for (String key : keys) {
+			Object storedHash = redisTemplate.opsForHash().get(key, FIELD_REFRESH_HASH);
+			if (storedHash != null) {
+				indexKeys.add(buildIndexKey(storedHash.toString()));
+			}
+		}
 		redisTemplate.delete(keys);
+		if (!indexKeys.isEmpty()) {
+			redisTemplate.delete(indexKeys);
+		}
 	}
 
 	private String buildKey(Long memberId, String sid) {
 		return KEY_PREFIX + memberId + ":" + sid;
+	}
+
+	private String buildIndexKey(String refreshHash) { // refreshHash -> sessionKey 역인덱스 키
+		return INDEX_PREFIX + refreshHash;
+	}
+
+	private String buildIndexValue(Long memberId, String sid) { // 역인덱스 값: "memberId:sid"
+		return memberId + ":" + sid;
+	}
+
+	private void deleteIndex(String refreshHash) { // 역인덱스 삭제 헬퍼
+		if (refreshHash == null || refreshHash.isBlank()) {
+			return;
+		}
+		redisTemplate.delete(buildIndexKey(refreshHash));
 	}
 
 	private String generateToken() {
@@ -115,5 +183,8 @@ public class RefreshTokenService {
 		} catch (NoSuchAlgorithmException ex) {
 			throw new IllegalStateException("SHA-256 not available", ex);
 		}
+	}
+
+	public record RefreshSession(Long memberId, String sid) { // refresh 토큰으로 해석된 세션 정보
 	}
 }

--- a/src/main/java/com/matchimban/matchimban_api/global/swagger/AuthRefreshErrorResponses.java
+++ b/src/main/java/com/matchimban/matchimban_api/global/swagger/AuthRefreshErrorResponses.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 @ApiResponses({
 	@ApiResponse(
 		responseCode = "401",
-		description = "invalid_refresh_token / invalid_access_token",
+		description = "invalid_refresh_token",
 		content = @Content(schema = @Schema(implementation = ErrorResponse.class))
 	),
 	@ApiResponse(

--- a/src/main/java/com/matchimban/matchimban_api/member/onboarding/config/OnboardingSeedData.java
+++ b/src/main/java/com/matchimban/matchimban_api/member/onboarding/config/OnboardingSeedData.java
@@ -55,7 +55,7 @@ public class OnboardingSeedData implements ApplicationRunner { //ApplicationRunn
 		7. 안전성 확보 조치
 		- 접근 통제, 암호화, 로그 관리 등 합리적 보호조치를 시행함.
 		8. 문의처
-		- 문의: support@matchimban.com
+		- 문의: support@moyeobab.com
 		""";
 
 	private final PolicyRepository policyRepository;


### PR DESCRIPTION
기존 문제: 리프레시로 액세스를 갱신하려는데, sid가 access 토큰 안에만 있어서 결국 access 토큰이 있어야만 refresh가 동작하는 아이러니가 발생했다.
(sid로 refresh:{memberId}:{sid}를 찾아 비교하는 구조였기 때문)

해결: refresh 토큰 해시 → (memberId, sid) 역인덱스를 Redis에 추가했다.
그래서 refresh 토큰만으로 세션을 찾고, 해당 세션의 해시를 비교한 뒤 access 갱신이 가능해졌다.